### PR TITLE
Development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.padrewin</groupId>
     <artifactId>confirm2drop</artifactId>
-    <version>1.3</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>confirm2drop</name>
@@ -100,6 +100,11 @@
             <url>https://repo.colddev.dev/</url>
         </repository>
 
+        <repository>
+            <id>placeholderapi-repo</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+
     </repositories>
 
     <dependencies>
@@ -116,6 +121,13 @@
             <artifactId>colddev</artifactId>
             <version>1.4.7</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/dev/padrewin/confirm2Drop/Confirm2Drop.java
+++ b/src/main/java/dev/padrewin/confirm2Drop/Confirm2Drop.java
@@ -7,6 +7,7 @@ import dev.padrewin.colddev.database.SQLiteConnector;
 import dev.padrewin.colddev.manager.Manager;
 import dev.padrewin.colddev.manager.PluginUpdateManager;
 import dev.padrewin.confirm2Drop.database.DatabaseManager;
+import dev.padrewin.confirm2Drop.hook.Confirm2DropPlaceholderExpansion;
 import dev.padrewin.confirm2Drop.manager.CommandManager;
 import dev.padrewin.confirm2Drop.manager.LocaleManager;
 import dev.padrewin.confirm2Drop.setting.SettingKey;
@@ -16,6 +17,9 @@ import org.bukkit.Bukkit;
 
 import java.io.File;
 import java.util.List;
+
+import static dev.padrewin.colddev.manager.AbstractDataManager.ANSI_BOLD;
+import static dev.padrewin.colddev.manager.AbstractDataManager.ANSI_LIGHT_BLUE;
 
 public final class Confirm2Drop extends ColdPlugin {
 
@@ -53,6 +57,14 @@ public final class Confirm2Drop extends ColdPlugin {
         DatabaseConnector connector = new SQLiteConnector(this);
         String databasePath = connector.getDatabasePath();
         getLogger().info(ANSI_GREEN + "Database path: " + ANSI_YELLOW + databasePath + ANSI_RESET);
+
+        // Initialize PlaceholderAPI
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new Confirm2DropPlaceholderExpansion(this).register();
+            getLogger().info(ANSI_LIGHT_BLUE + "PlaceholderAPI hook registered successfully. " + ANSI_BOLD + ANSI_GREEN + "✔" + ANSI_RESET);
+        } else {
+            getLogger().warning(ANSI_LIGHT_BLUE + "PlaceholderAPI not found. " + ANSI_BOLD + ANSI_RED + "✘" + ANSI_RESET);
+        }
 
         getManager(PluginUpdateManager.class);
 

--- a/src/main/java/dev/padrewin/confirm2Drop/commands/ToggleCommand.java
+++ b/src/main/java/dev/padrewin/confirm2Drop/commands/ToggleCommand.java
@@ -1,5 +1,6 @@
 package dev.padrewin.confirm2Drop.commands;
 
+import dev.padrewin.colddev.utils.StringPlaceholders;
 import dev.padrewin.confirm2Drop.Confirm2Drop;
 import dev.padrewin.confirm2Drop.listeners.DropListener;
 import dev.padrewin.confirm2Drop.manager.CommandManager;
@@ -18,13 +19,13 @@ public class ToggleCommand extends BaseCommand {
 
     @Override
     public void execute(Confirm2Drop plugin, CommandSender sender, String[] args) {
+        LocaleManager localeManager = plugin.getManager(LocaleManager.class);
         if (!(sender instanceof Player)) {
-            plugin.getManager(LocaleManager.class).sendMessage(sender, "player-only-command");
+            localeManager.sendMessage(sender, "player-only-command");
             return;
         }
 
         Player player = (Player) sender;
-        LocaleManager localeManager = plugin.getManager(LocaleManager.class);
         String uuid = player.getUniqueId().toString();
         String playerName = player.getName();
 
@@ -48,11 +49,17 @@ public class ToggleCommand extends BaseCommand {
         boolean newPreference = !currentPreference;
         plugin.getDatabaseManager().savePlayerPreference(uuid, playerName, newPreference);
 
-        DropListener dropListener = plugin.getDropListener();
-        dropListener.resetPendingConfirmation(player);
+        plugin.getDropListener().resetPendingConfirmation(player);
 
-        String messageKey = newPreference ? "command-toggle-enabled" : "command-toggle-disabled";
-        localeManager.sendMessage(player, messageKey);
+        String toggleStatus = newPreference
+                ? localeManager.getLocaleMessage("placeholder-status-enabled")
+                : localeManager.getLocaleMessage("placeholder-status-disabled");
+
+        localeManager.sendMessage(
+                player,
+                "command-toggle-status",
+                StringPlaceholders.builder("confirm2drop_toggle_status", toggleStatus).build()
+        );
     }
 
 

--- a/src/main/java/dev/padrewin/confirm2Drop/hook/Confirm2DropPlaceholderExpansion.java
+++ b/src/main/java/dev/padrewin/confirm2Drop/hook/Confirm2DropPlaceholderExpansion.java
@@ -1,0 +1,48 @@
+package dev.padrewin.confirm2Drop.hook;
+
+import dev.padrewin.confirm2Drop.Confirm2Drop;
+import dev.padrewin.confirm2Drop.manager.LocaleManager;
+import org.bukkit.OfflinePlayer;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+
+public class Confirm2DropPlaceholderExpansion extends PlaceholderExpansion {
+
+    private final Confirm2Drop confirm2Drop;
+    private final LocaleManager localeManager;
+
+    public Confirm2DropPlaceholderExpansion(Confirm2Drop confirm2Drop) {
+        this.confirm2Drop = confirm2Drop;
+        this.localeManager = this.confirm2Drop.getManager(LocaleManager.class);
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, String placeholder) {
+        if (player != null && placeholder.equalsIgnoreCase("toggle_status")) {
+            boolean isEnabled = this.confirm2Drop.getDatabaseManager().getPlayerPreference(player.getUniqueId().toString());
+            return isEnabled
+                    ? localeManager.getLocaleMessage("placeholder-status-enabled")
+                    : localeManager.getLocaleMessage("placeholder-status-disabled");
+        }
+        return null;
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "confirm2drop";
+    }
+
+    @Override
+    public String getAuthor() {
+        return this.confirm2Drop.getDescription().getAuthors().get(0);
+    }
+
+    @Override
+    public String getVersion() {
+        return this.confirm2Drop.getDescription().getVersion();
+    }
+}

--- a/src/main/resources/locale/en_US.yml
+++ b/src/main/resources/locale/en_US.yml
@@ -16,13 +16,14 @@ invalid-command-usage: '&cInvalid command usage.'
 player-only-command: '&cThis command can only be used by players!'
 drop-confirmation-message: "&7You need to drop the item again to confirm the action. To disable confirmation, use &c/confirm2drop toggle&7."
 plugin-disabled-message: '&cOops! This feature is currently turned off in the server settings. Contact the server owner.'
+placeholder-status-enabled: "&aenabled"
+placeholder-status-disabled: "&cdisabled"
 
 # Toggle Command Message
 command-toggle-description: '&8 - &c/confirm2drop toggle &7- Toggles drop confirmation for the player'
 command-toggle-usage: "&7Usage: &c/confirm2drop toggle confirm"
 command-toggle-warning: "&eWARNING: &7Are you sure you want to toggle drop confirmation? Use &c/confirm2drop toggle confirm &7to proceed."
-command-toggle-enabled: '&7Drop confirmation has been &aenabled&7!'
-command-toggle-disabled: '&7Drop confirmation has been &cdisabled&7!'
+command-toggle-status: '&7Drop confirmation is now: %confirm2drop_toggle_status%&7.'
 
 # Reload Command
 command-reload-description: '&8 - &c/confirm2drop reload &7- Reloads the plugin'

--- a/src/main/resources/locale/fr_FR.yml
+++ b/src/main/resources/locale/fr_FR.yml
@@ -3,31 +3,32 @@ prefix: '&8「&#635AA7C&#7D72B7o&#978BC7n&#B2A3D8f&#CCBCE8i&#E6D4F8r&#D8B8F8m&#C
 
 # Base Command Message
 base-command-color: '&7'
-base-command-help: '&7Utilisez &c/confirm2drop help &7pour obtenir des informations sur les commandes.'
+base-command-help: '&7Utilisez &c/confirm2drop help &7pour les informations sur les commandes.'
 
 # Help Command
 command-help-description: '&8 - &c/confirm2drop help &7- Affiche le menu d''aide'
-command-help-title: '&cCommandes Disponibles :'
+command-help-title: '&cCommandes disponibles :'
 
 # Misc
-no-permission: '&cVous n''avez pas la permission pour cela !'
+no-permission: '&cVous n''avez pas la permission de faire cela !'
 unknown-command: '&cCommande inconnue &4%input%&c.'
 invalid-command-usage: '&cUtilisation invalide de la commande.'
-player-only-command: '&cCette commande est réservée aux joueurs !'
-drop-confirmation-message: '&7Vous devez rejeter à nouveau l''objet pour confirmer l''action. Pour désactiver la confirmation, utilisez &c/confirm2drop toggle&7.'
-plugin-disabled-message: '&cOups ! Cette fonctionnalité est actuellement désactivée dans les paramètres du serveur. Contactez l''administrateur du serveur.'
+player-only-command: '&cCette commande ne peut être utilisée que par des joueurs !'
+drop-confirmation-message: "&7Vous devez déposer l''objet à nouveau pour confirmer l''action. Pour désactiver la confirmation, utilisez &c/confirm2drop toggle&7."
+plugin-disabled-message: '&cOups ! Cette fonctionnalité est actuellement désactivée dans les paramètres du serveur. Contactez l''administrateur.'
+placeholder-status-enabled: "&aactivé"
+placeholder-status-disabled: "&cdésactivé"
 
 # Toggle Command Message
-command-toggle-description: '&8 - &c/confirm2drop toggle &7- Active/Désactive la confirmation pour le joueur'
-command-toggle-usage: '&7Utilisation : &c/confirm2drop toggle confirm'
-command-toggle-warning: '&eAVERTISSEMENT : &cÊtes-vous sûr de vouloir activer/désactiver la confirmation ? Utilisez &a/confirm2drop toggle confirm &cpour continuer.'
-command-toggle-enabled: '&7La confirmation de rejet a été &aactivée&7 !'
-command-toggle-disabled: '&7La confirmation de rejet a été &cdésactivée&7 !'
+command-toggle-description: '&8 - &c/confirm2drop toggle &7- Active ou désactive la confirmation des dépôts pour le joueur'
+command-toggle-usage: "&7Utilisation : &c/confirm2drop toggle confirm"
+command-toggle-warning: "&eATTENTION : &7Êtes-vous sûr de vouloir basculer la confirmation des dépôts ? Utilisez &c/confirm2drop toggle confirm &7pour continuer."
+command-toggle-status: '&7La confirmation des dépôts est réglée sur : %confirm2drop_toggle_status%&7 !'
 
 # Reload Command
 command-reload-description: '&8 - &c/confirm2drop reload &7- Recharge le plugin'
 command-reload-usage: '&7Utilisation : &c/confirm2drop reload'
-command-reload-success: '&7Les fichiers de configuration et de localisation ont été rechargés avec succès.'
+command-reload-success: '&7Les fichiers de configuration et de langue ont été rechargés avec succès.'
 
 # Version Command
-command-version-description: '&8 - &c/confirm2drop version &7- Affiche les informations de version pour Confirm2Drop'
+command-version-description: '&8 - &c/confirm2drop version &7- Affiche les informations de version de Confirm2Drop'

--- a/src/main/resources/locale/pt_PT.yml
+++ b/src/main/resources/locale/pt_PT.yml
@@ -3,31 +3,32 @@ prefix: '&8「&#635AA7C&#7D72B7o&#978BC7n&#B2A3D8f&#CCBCE8i&#E6D4F8r&#D8B8F8m&#C
 
 # Base Command Message
 base-command-color: '&7'
-base-command-help: '&7Use &c/confirm2drop help &7para informações sobre os comandos.'
+base-command-help: '&7Use &c/confirm2drop help &7para informações sobre comandos.'
 
 # Help Command
-command-help-description: '&8 - &c/confirm2drop help &7- Exibe o menu de ajuda'
+command-help-description: '&8 - &c/confirm2drop help &7- Mostra o menu de ajuda'
 command-help-title: '&cComandos Disponíveis:'
 
 # Misc
-no-permission: '&cVocê não tem permissão para isso!'
+no-permission: '&cVocê não tem permissão para fazer isso!'
 unknown-command: '&cComando desconhecido &4%input%&c.'
 invalid-command-usage: '&cUso inválido do comando.'
 player-only-command: '&cEste comando só pode ser usado por jogadores!'
-drop-confirmation-message: '&7Você precisa soltar o item novamente para confirmar a ação. Para desativar a confirmação, use &c/confirm2drop toggle&7.'
-plugin-disabled-message: '&cOps! Este recurso está desativado nas configurações do servidor. Entre em contato com o administrador do servidor.'
+drop-confirmation-message: "&7Você precisa soltar o item novamente para confirmar a ação. Para desativar a confirmação, use &c/confirm2drop toggle&7."
+plugin-disabled-message: '&cOps! Este recurso está desativado nas configurações do servidor. Contate o administrador.'
+placeholder-status-enabled: "&aativado"
+placeholder-status-disabled: "&cdesativado"
 
 # Toggle Command Message
-command-toggle-description: '&8 - &c/confirm2drop toggle &7- Alterna a confirmação de drop para o jogador'
-command-toggle-usage: '&7Uso: &c/confirm2drop toggle confirm'
-command-toggle-warning: '&eAVISO: &cTem certeza de que deseja alternar a confirmação de drop? Use &a/confirm2drop toggle confirm &cpara continuar.'
-command-toggle-enabled: '&7A confirmação de drop foi &aativada&7!'
-command-toggle-disabled: '&7A confirmação de drop foi &cdesativada&7!'
+command-toggle-description: '&8 - &c/confirm2drop toggle &7- Ativa ou desativa a confirmação de soltar para o jogador'
+command-toggle-usage: "&7Uso: &c/confirm2drop toggle confirm"
+command-toggle-warning: "&eAVISO: &7Tem certeza de que deseja alternar a confirmação de soltar? Use &c/confirm2drop toggle confirm &7para continuar."
+command-toggle-status: '&7A confirmação de soltar foi definida para: %confirm2drop_toggle_status%&7!'
 
 # Reload Command
 command-reload-description: '&8 - &c/confirm2drop reload &7- Recarrega o plugin'
 command-reload-usage: '&7Uso: &c/confirm2drop reload'
-command-reload-success: '&7Os arquivos de configuração e locais foram recarregados com sucesso.'
+command-reload-success: '&7Os arquivos de configuração e idioma foram recarregados com sucesso.'
 
 # Version Command
-command-version-description: '&8 - &c/confirm2drop version &7- Exibe informações da versão do Confirm2Drop'
+command-version-description: '&8 - &c/confirm2drop version &7- Mostra as informações de versão do Confirm2Drop'

--- a/src/main/resources/locale/ro_RO.yml
+++ b/src/main/resources/locale/ro_RO.yml
@@ -3,31 +3,32 @@ prefix: '&8「&#635AA7C&#7D72B7o&#978BC7n&#B2A3D8f&#CCBCE8i&#E6D4F8r&#D8B8F8m&#C
 
 # Base Command Message
 base-command-color: '&7'
-base-command-help: '&7Folosește &c/confirm2drop help &7pentru informații despre comenzi.'
+base-command-help: '&7Folosiți &c/confirm2drop help &7pentru informații despre comenzi.'
 
 # Help Command
 command-help-description: '&8 - &c/confirm2drop help &7- Afișează meniul de ajutor'
-command-help-title: '&cComenzi Disponibile:'
+command-help-title: '&cComenzi disponibile:'
 
 # Misc
-no-permission: '&cNu ai permisiunea pentru această acțiune!'
+no-permission: '&cNu aveți permisiunea necesară pentru asta!'
 unknown-command: '&cComandă necunoscută &4%input%&c.'
 invalid-command-usage: '&cUtilizare invalidă a comenzii.'
-player-only-command: '&cAceastă comandă poate fi utilizată doar de jucători!'
-drop-confirmation-message: '&7Trebuie să arunci din nou obiectul pentru a confirma acțiunea. Pentru a dezactiva confirmarea, folosește &c/confirm2drop toggle&7.'
-plugin-disabled-message: '&cUps! Această funcționalitate este dezactivată în setările serverului. Contactează ownerul serverului.'
+player-only-command: '&cAceastă comandă poate fi folosită doar de jucători!'
+drop-confirmation-message: "&7Trebuie să aruncați din nou obiectul pentru a confirma acțiunea. Pentru a dezactiva confirmarea, utilizați &c/confirm2drop toggle&7."
+plugin-disabled-message: '&cUps! Această funcție este dezactivată în setările serverului. Contactați administratorul.'
+placeholder-status-enabled: "&aactivat"
+placeholder-status-disabled: "&cdezactivat"
 
 # Toggle Command Message
-command-toggle-description: '&8 - &c/confirm2drop toggle &7- Activează/dezactivează confirmarea pentru drop pentru jucător'
-command-toggle-usage: '&7Utilizare: &c/confirm2drop toggle confirm'
-command-toggle-warning: '&eAVERTISMENT: &cEști sigur că vrei să activezi/dezactivezi confirmarea drop-ului? Folosește &a/confirm2drop toggle confirm &cpentru a continua.'
-command-toggle-enabled: '&7Confirmarea drop-ului a fost &aactivată&7!'
-command-toggle-disabled: '&7Confirmarea drop-ului a fost &cdezactivată&7!'
+command-toggle-description: '&8 - &c/confirm2drop toggle &7- Activează sau dezactivează confirmarea aruncării pentru jucător'
+command-toggle-usage: "&7Utilizare: &c/confirm2drop toggle confirm"
+command-toggle-warning: "&eAVERTISMENT: &7Ești sigur că vrei să modifici starea confirmării? Folosește &c/confirm2drop toggle confirm &7pentru a continua."
+command-toggle-status: '&7Confirmarea aruncării: %confirm2drop_toggle_status%&7.'
 
 # Reload Command
 command-reload-description: '&8 - &c/confirm2drop reload &7- Reîncarcă pluginul'
 command-reload-usage: '&7Utilizare: &c/confirm2drop reload'
-command-reload-success: '&7Fișierele de configurație și locale au fost reîncărcate cu succes.'
+command-reload-success: '&7Fișierele de configurare și localizare au fost reîncărcate cu succes.'
 
 # Version Command
 command-version-description: '&8 - &c/confirm2drop version &7- Afișează informațiile despre versiunea Confirm2Drop'

--- a/src/main/resources/locale/zh_CN.yml
+++ b/src/main/resources/locale/zh_CN.yml
@@ -3,31 +3,32 @@ prefix: '&8「&#635AA7C&#7D72B7o&#978BC7n&#B2A3D8f&#CCBCE8i&#E6D4F8r&#D8B8F8m&#C
 
 # Base Command Message
 base-command-color: '&7'
-base-command-help: '&7使用 &c/confirm2drop help &7查看指令信息。'
+base-command-help: '&7使用 &c/confirm2drop help &7查看命令信息。'
 
 # Help Command
 command-help-description: '&8 - &c/confirm2drop help &7- 显示帮助菜单'
-command-help-title: '&c可用指令:'
+command-help-title: '&c可用命令：'
 
 # Misc
 no-permission: '&c你没有权限执行此操作！'
-unknown-command: '&c未知指令 &4%input%&c。'
-invalid-command-usage: '&c指令使用无效。'
-player-only-command: '&c此指令仅限玩家使用！'
-drop-confirmation-message: '&7你需要再次丢弃该物品以确认操作。若要禁用确认，请使用 &c/confirm2drop toggle&7。'
-plugin-disabled-message: '&c抱歉！此功能已在服务器设置中关闭。请联系服务器管理员。'
+unknown-command: '&c未知命令 &4%input%&c。'
+invalid-command-usage: '&c无效的命令用法。'
+player-only-command: '&c此命令只能由玩家使用！'
+drop-confirmation-message: "&7您需要再次丢弃物品以确认操作。要禁用确认功能，请使用 &c/confirm2drop toggle&7。"
+plugin-disabled-message: '&c抱歉！此功能已在服务器设置中禁用。请联系服务器管理员。'
+placeholder-status-enabled: "&a启用"
+placeholder-status-disabled: "&c禁用"
 
 # Toggle Command Message
-command-toggle-description: '&8 - &c/confirm2drop toggle &7- 切换玩家的丢弃确认'
-command-toggle-usage: '&7用法: &c/confirm2drop toggle confirm'
-command-toggle-warning: '&e警告: &c你确定要切换丢弃确认吗？使用 &a/confirm2drop toggle confirm &c继续。'
-command-toggle-enabled: '&7丢弃确认已被 &a启用&7！'
-command-toggle-disabled: '&7丢弃确认已被 &c禁用&7！'
+command-toggle-description: '&8 - &c/confirm2drop toggle &7- 切换玩家的丢弃确认功能'
+command-toggle-usage: "&7用法： &c/confirm2drop toggle confirm"
+command-toggle-warning: "&e警告： &7确定要切换丢弃确认功能吗？使用 &c/confirm2drop toggle confirm &7继续。"
+command-toggle-status: '&7丢弃确认已设置为：%confirm2drop_toggle_status%&7！'
 
 # Reload Command
 command-reload-description: '&8 - &c/confirm2drop reload &7- 重新加载插件'
-command-reload-usage: '&7用法: &c/confirm2drop reload'
-command-reload-success: '&7配置和本地化文件已成功重新加载。'
+command-reload-usage: '&7用法： &c/confirm2drop reload'
+command-reload-success: '&7配置文件和本地化文件已成功重新加载。'
 
 # Version Command
-command-version-description: '&8 - &c/confirm2drop version &7- 显示 Confirm2Drop 插件版本信息'
+command-version-description: '&8 - &c/confirm2drop version &7- 显示 Confirm2Drop 的版本信息'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ website: 'https://github.com/Cold-Development/Confirm2Drop'
 description: A plugin that requires confirmation to drop specific items.
 main: dev.padrewin.confirm2Drop.Confirm2Drop
 api-version: '1.20'
-load: STARTUP
+softdepend: [PlaceholderAPI]
 folia-supported: true
 libraries:
   - 'org.xerial:sqlite-jdbc:3.46.0.0'


### PR DESCRIPTION
+ Added support for PlaceholderAPI
- %confirm2drop_toggle_status% can be now used anywhere as placeholder to return the current status of the drop confirmation whether is enabled or disabled
- locale changes (all files)